### PR TITLE
Remove dependency on git-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ there, watch for changes and re-build when editing files in `src/`. It'll also
 open your default browser at http://localhost:8001 and live-reload on changes
 (which might not work on some systems).
 
-	npm run dev
+    npm run dev
 
 Check out the "scripts" part of `package.json` for the various `npm run`
 commands for the respective tasks.
@@ -36,8 +36,8 @@ commands for the respective tasks.
 Deploying the site to [GitHub pages](https://remotestorage.github.io/website/)
 for testing/review:
 
-	./deploy
+    ./deploy
 
 Deploying to production (need 5apps remote set, see comment in deploy script):
 
-	./deploy production
+    ./deploy production

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ there, watch for changes and re-build when editing files in `src/`. It'll also
 open your default browser at http://localhost:8001 and live-reload on changes
 (which might not work on some systems).
 
-    npm run dev
+	npm run dev
 
 Check out the "scripts" part of `package.json` for the various `npm run`
 commands for the respective tasks.
@@ -36,12 +36,8 @@ commands for the respective tasks.
 Deploying the site to [GitHub pages](https://remotestorage.github.io/website/)
 for testing/review:
 
-    ./deploy
-
-This currently requires [git-up](https://github.com/aanand/git-up) to be
-installed. You can comment the line, if you want. Make sure you're up-to-date
-on all branches yourself then.
+	./deploy
 
 Deploying to production (need 5apps remote set, see comment in deploy script):
 
-    ./deploy production
+	./deploy production

--- a/deploy
+++ b/deploy
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-git up
+git pull --rebase --autostash
 npm run build:dist
 git checkout gh-pages
 cp -r out/* .


### PR DESCRIPTION
As stated in the git-up repo, git has solved the problems git-up was trying
to address. So we don't need to require developers to have it installed.