### PR TITLE
use accessible colors on diagrams

### DIFF
--- a/src/public/img/explainer-1-traditional-webapp-scoured.svg
+++ b/src/public/img/explainer-1-traditional-webapp-scoured.svg
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg id="svg2" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" xmlns:osb="http://www.openswatchbook.org/uri/2009/osb" viewBox="0 0 411.49175 255.93454" height="72.23mm" width="116.13mm" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/">
+ <style>
+  .developer {fill: #f5793a;}
+  .user {fill: #85c0f9;}
+ </style>
  <defs id="defs4">
-  <linearGradient id="linearGradient9925" osb:paint="solid">
-   <stop id="stop9927" stop-color="#ff5100" offset="0"/>
-  </linearGradient>
   <marker id="marker4847" refY="0" refX="0" overflow="visible" orient="auto">
    <path id="path4849" stroke-linejoin="round" d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z" fill-rule="evenodd" transform="matrix(-1.1,0,0,-1.1,-1.1,0)" stroke="#000" stroke-width=".625"/>
   </marker>
@@ -16,11 +17,6 @@
   <marker id="marker4697" refY="0" refX="0" orient="auto" overflow="visible">
    <path id="path4699" stroke-linejoin="round" d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z" fill-rule="evenodd" transform="matrix(1.1,0,0,1.1,1.1,0)" stroke="#000" stroke-width=".625"/>
   </marker>
-  <linearGradient id="linearGradient9917" y2="565.72" gradientUnits="userSpaceOnUse" y1="565.72" gradientTransform="translate(7.0711 -268.68)" x2="289.59" x1="109.74">
-   <stop id="stop9915" stop-color="#97ee00" offset="0"/>
-  </linearGradient>
-  <linearGradient id="linearGradient9929" y2="400.14" xlink:href="#linearGradient9925" gradientUnits="userSpaceOnUse" y1="400.14" gradientTransform="translate(7.0711 -268.68)" x2="289.59" x1="109.74"/>
-  <linearGradient id="linearGradient9935" y2="515.67" xlink:href="#linearGradient9925" gradientUnits="userSpaceOnUse" y1="515.67" x2="230.46" x1="16.507"/>
  </defs>
  <metadata id="metadata7">
   <rdf:RDF>
@@ -32,10 +28,10 @@
   </rdf:RDF>
  </metadata>
  <g id="layer1" transform="translate(-116.81 -86.029)">
-  <path id="path4158-2" stroke-linejoin="round" d="m140.28 258.69a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-7.3544 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-6.9448 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm18.229-3.8221h147.9v8.4h-147.9zm-27.149-2.5002h179.35v89.346h-179.35z" stroke="#000" stroke-linecap="round" stroke-width=".5" fill="url(#linearGradient9917)"/>
-  <rect id="rect4136-6" stroke-linejoin="round" height="89.346" width="179.35" stroke="#000" stroke-linecap="round" y="86.791" x="117.06" stroke-width=".5" fill="url(#linearGradient9929)"/>
-  <g id="g4325" transform="matrix(.66990 0 0 .64772 373.92 -202.54)" stroke-width=".75906" fill="url(#linearGradient9935)">
-   <path id="path1934" stroke-linejoin="round" d="m229.66 458.75c0 7.166-47.748 13.111-105.8 13.111-58.056 0-106.75-5.8158-106.75-12.982 0-7.166 48.693-12.982 106.75-12.982 58.056 0 105.8 5.6867 105.8 12.853zm0.008-0.0254 0.40979 112.77c0 6.3034-47.5 13.936-106.03 13.936-58.527 0-107.17-7.4228-107.17-13.726l0.151-112.85" fill-rule="evenodd" stroke="#000" stroke-width=".75906" fill="url(#linearGradient9935)"/>
+  <path id="path4158-2" class="user" stroke-linejoin="round" d="m140.28 258.69a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-7.3544 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-6.9448 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm18.229-3.8221h147.9v8.4h-147.9zm-27.149-2.5002h179.35v89.346h-179.35z" stroke="#000" stroke-linecap="round" stroke-width=".5"/>
+  <rect id="rect4136-6" class="developer" stroke-linejoin="round" height="89.346" width="179.35" stroke="#000" stroke-linecap="round" y="86.791" x="117.06" stroke-width=".5"/>
+  <g id="g4325" transform="matrix(.66990 0 0 .64772 373.92 -202.54)" stroke-width=".75906">
+   <path id="path1934" class="developer" stroke-linejoin="round" d="m229.66 458.75c0 7.166-47.748 13.111-105.8 13.111-58.056 0-106.75-5.8158-106.75-12.982 0-7.166 48.693-12.982 106.75-12.982 58.056 0 105.8 5.6867 105.8 12.853zm0.008-0.0254 0.40979 112.77c0 6.3034-47.5 13.936-106.03 13.936-58.527 0-107.17-7.4228-107.17-13.726l0.151-112.85" stroke="#000" stroke-width=".75906"/>
   </g>
   <text id="text4367" style="word-spacing:0px;letter-spacing:0px" xml:space="preserve" font-size="40px" line-height="125%" y="136.01041" x="140.95952" font-family="Sans" fill="#000000"><tspan id="tspan4369" font-size="17.5px" y="136.01041" x="140.95952" font-family="&apos;Open Sans&apos;">Web Application</tspan></text>
   <text id="text4367-4" style="word-spacing:0px;letter-spacing:0px" xml:space="preserve" font-size="40px" line-height="125%" y="140.42429" x="437.285" font-family="Sans" fill="#000000"><tspan id="tspan4389" font-size="17.5px" y="140.42429" x="437.285" font-family="&apos;Open Sans&apos;">Data</tspan></text>

--- a/src/public/img/explainer-2-no-backend-scoured.svg
+++ b/src/public/img/explainer-2-no-backend-scoured.svg
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg id="svg2" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" xmlns:osb="http://www.openswatchbook.org/uri/2009/osb" viewBox="0 0 411.49175 255.93454" height="72.23mm" width="116.13mm" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/">
+ <style>
+  .developer {fill: #f5793a;}
+  .user {fill: #85c0f9;}
+ </style>
  <defs id="defs4">
-  <linearGradient id="linearGradient9925" osb:paint="solid">
-   <stop id="stop9927" stop-color="#ff5100" offset="0"/>
-  </linearGradient>
   <marker id="marker7744" refY="0" refX="0" orient="auto" overflow="visible">
    <path id="path7746" stroke-linejoin="round" d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z" fill-rule="evenodd" transform="matrix(1.1,0,0,1.1,1.1,0)" stroke="#000" stroke-width=".625"/>
   </marker>
@@ -13,11 +14,6 @@
   <marker id="Arrow2Lend-5" refY="0" refX="0" orient="auto" overflow="visible">
    <path id="path4442-8" stroke-linejoin="round" d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z" fill-rule="evenodd" transform="matrix(-1.1,0,0,-1.1,-1.1,0)" stroke="#000" stroke-width=".625"/>
   </marker>
-  <linearGradient id="linearGradient9961" y2="750.63" xlink:href="#linearGradient9925" gradientUnits="userSpaceOnUse" y1="750.63" gradientTransform="translate(5.0508 -289.89)" x2="291.29" x1="111.44"/>
-  <linearGradient id="linearGradient9967" y2="515.67" xlink:href="#linearGradient9925" gradientUnits="userSpaceOnUse" y1="515.67" x2="230.46" x1="16.507"/>
-  <linearGradient id="linearGradient9973" y2="916.2" gradientUnits="userSpaceOnUse" y1="916.2" gradientTransform="translate(5.0508 -289.89)" x2="291.29" x1="111.44">
-   <stop id="stop9921" stop-color="#97ee00" offset="0"/>
-  </linearGradient>
  </defs>
  <metadata id="metadata7">
   <rdf:RDF>
@@ -29,10 +25,10 @@
   </rdf:RDF>
  </metadata>
  <g id="layer1" transform="translate(-116.49 -415.82)">
-  <path id="path4158-2-9" stroke-linejoin="round" d="m139.96 587.96a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-7.3544 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-6.9448 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm18.229-3.8221h147.9v8.4h-147.9zm-27.149-2.5002h179.35v89.346h-179.35z" stroke="#000" stroke-linecap="round" stroke-width=".5" fill="url(#linearGradient9973)"/>
-  <rect id="rect4136-6-9" stroke-linejoin="round" height="89.346" width="179.35" stroke="#000" stroke-linecap="round" y="416.07" x="116.74" stroke-width=".5" fill="url(#linearGradient9961)"/>
-  <g id="g4325-8" transform="matrix(.66990 0 0 .64772 373.6 292.31)" stroke-width=".75906" fill="url(#linearGradient9967)">
-   <path id="path1934-3" stroke-linejoin="round" d="m229.66 458.75c0 7.166-47.748 13.111-105.8 13.111-58.056 0-106.75-5.8158-106.75-12.982 0-7.166 48.693-12.982 106.75-12.982 58.056 0 105.8 5.6867 105.8 12.853zm0.008-0.0254 0.40979 112.77c0 6.3034-47.5 13.936-106.03 13.936-58.527 0-107.17-7.4228-107.17-13.726l0.151-112.85" fill-rule="evenodd" stroke="#000" stroke-width=".75906" fill="url(#linearGradient9967)"/>
+  <path class="user" id="path4158-2-9" stroke-linejoin="round" d="m139.96 587.96a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-7.3544 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-6.9448 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm18.229-3.8221h147.9v8.4h-147.9zm-27.149-2.5002h179.35v89.346h-179.35z" stroke="#000" stroke-linecap="round" stroke-width=".5"/>
+  <rect class="developer" id="rect4136-6-9" stroke-linejoin="round" height="89.346" width="179.35" stroke="#000" stroke-linecap="round" y="416.07" x="116.74" stroke-width=".5"/>
+  <g id="g4325-8" transform="matrix(.66990 0 0 .64772 373.6 292.31)" stroke-width=".75906">
+   <path class="developer" id="path1934-3" stroke-linejoin="round" d="m229.66 458.75c0 7.166-47.748 13.111-105.8 13.111-58.056 0-106.75-5.8158-106.75-12.982 0-7.166 48.693-12.982 106.75-12.982 58.056 0 105.8 5.6867 105.8 12.853zm0.008-0.0254 0.40979 112.77c0 6.3034-47.5 13.936-106.03 13.936-58.527 0-107.17-7.4228-107.17-13.726l0.151-112.85" stroke="#000" stroke-width=".75906"/>
   </g>
   <text id="text4367-6" style="word-spacing:0px;letter-spacing:0px" xml:space="preserve" font-size="40px" line-height="125%" y="465.2851" x="140.64137" font-family="Sans" fill="#000000"><tspan id="tspan4369-55" font-size="17.5px" y="465.2851" x="140.64137" font-family="&apos;Open Sans&apos;">Web Application</tspan></text>
   <text id="text4367-4-3" style="word-spacing:0px;letter-spacing:0px" xml:space="preserve" font-size="40px" line-height="125%" y="637.69897" x="436.96689" font-family="Sans" fill="#000000"><tspan id="tspan4389-9" font-size="17.5px" y="637.69897" x="436.96689" font-family="&apos;Open Sans&apos;">Data</tspan></text>

--- a/src/public/img/explainer-3-unhosted-scoured.svg
+++ b/src/public/img/explainer-3-unhosted-scoured.svg
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg id="svg2" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" xmlns:osb="http://www.openswatchbook.org/uri/2009/osb" viewBox="0 0 411.49172 255.93449" height="72.23mm" width="116.13mm" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/">
+ <style>
+  .developer {fill: #f5793a;}
+  .user {fill: #85c0f9;}
+ </style>
  <defs id="defs4">
-  <linearGradient id="linearGradient9919" osb:paint="solid">
-   <stop id="stop9921" stop-color="#97ee00" offset="0"/>
-  </linearGradient>
   <marker id="marker8343" refY="0" refX="0" overflow="visible" orient="auto">
    <path id="path8345" stroke-linejoin="round" d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z" fill-rule="evenodd" transform="matrix(-1.1,0,0,-1.1,-1.1,0)" stroke="#000" stroke-width=".625"/>
   </marker>
@@ -13,11 +14,6 @@
   <marker id="marker8039" refY="0" refX="0" overflow="visible" orient="auto">
    <path id="path8041" stroke-linejoin="round" d="m8.7186 4.0337-10.926-4.0177 10.926-4.0177c-1.7455 2.3721-1.7354 5.6175-6e-7 8.0354z" fill-rule="evenodd" transform="matrix(1.1,0,0,1.1,1.1,0)" stroke="#000" stroke-width=".625"/>
   </marker>
-  <linearGradient id="linearGradient9979" y2="587.48" gradientUnits="userSpaceOnUse" y1="587.48" gradientTransform="translate(-488.91 215.16)" x2="788.28" x1="608.44">
-   <stop id="stop9927" stop-color="#ff5100" offset="0"/>
-  </linearGradient>
-  <linearGradient id="linearGradient9985" y2="753.06" xlink:href="#linearGradient9919" gradientUnits="userSpaceOnUse" y1="753.06" gradientTransform="translate(-488.91 215.16)" x2="788.28" x1="608.44"/>
-  <linearGradient id="linearGradient9991" y2="515.67" xlink:href="#linearGradient9919" gradientUnits="userSpaceOnUse" y1="515.67" x2="230.46" x1="16.507"/>
  </defs>
  <metadata id="metadata7">
   <rdf:RDF>
@@ -29,10 +25,10 @@
   </rdf:RDF>
  </metadata>
  <g id="layer1" transform="translate(-119.52 -757.72)">
-  <path id="path4158-2-9-2" stroke-linejoin="round" d="m142.99 929.87a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-7.3544 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-6.9448 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm18.229-3.8221h147.9v8.4h-147.9zm-27.149-2.5002h179.35v89.346h-179.35z" stroke="#000" stroke-linecap="round" stroke-width=".5" fill="url(#linearGradient9985)"/>
-  <rect id="rect4136-6-9-9" stroke-linejoin="round" height="89.346" width="179.35" stroke="#000" stroke-linecap="round" y="757.97" x="119.77" stroke-width=".5" fill="url(#linearGradient9979)"/>
-  <g id="g4325-8-3" transform="matrix(.66990 0 0 .64772 376.63 634.21)" stroke-width=".75906" fill="url(#linearGradient9991)">
-   <path id="path1934-3-0" stroke-linejoin="round" d="m229.66 458.75c0 7.166-47.748 13.111-105.8 13.111-58.056 0-106.75-5.8158-106.75-12.982 0-7.166 48.693-12.982 106.75-12.982 58.056 0 105.8 5.6867 105.8 12.853zm0.008-0.0254 0.40979 112.77c0 6.3034-47.5 13.936-106.03 13.936-58.527 0-107.17-7.4228-107.17-13.726l0.151-112.85" fill-rule="evenodd" stroke="#000" stroke-width=".75906" fill="url(#linearGradient9991)"/>
+  <path class="user" id="path4158-2-9-2" stroke-linejoin="round" d="m142.99 929.87a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-7.3544 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm-6.9448 0a2.4842 2.4686 0 0 1 -2.4842 2.4686 2.4842 2.4686 0 0 1 -2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 -2.4686 2.4842 2.4686 0 0 1 2.4842 2.4686zm18.229-3.8221h147.9v8.4h-147.9zm-27.149-2.5002h179.35v89.346h-179.35z" stroke="#000" stroke-linecap="round" stroke-width=".5"/>
+  <rect class="developer" id="rect4136-6-9-9" stroke-linejoin="round" height="89.346" width="179.35" stroke="#000" stroke-linecap="round" y="757.97" x="119.77" stroke-width=".5"/>
+  <g id="g4325-8-3" transform="matrix(.66990 0 0 .64772 376.63 634.21)" stroke-width=".75906">
+   <path class="user" id="path1934-3-0" stroke-linejoin="round" d="m229.66 458.75c0 7.166-47.748 13.111-105.8 13.111-58.056 0-106.75-5.8158-106.75-12.982 0-7.166 48.693-12.982 106.75-12.982 58.056 0 105.8 5.6867 105.8 12.853zm0.008-0.0254 0.40979 112.77c0 6.3034-47.5 13.936-106.03 13.936-58.527 0-107.17-7.4228-107.17-13.726l0.151-112.85" stroke="#000" stroke-width=".75906"/>
   </g>
   <text id="text4367-6-9" style="word-spacing:0px;letter-spacing:0px" xml:space="preserve" font-size="40px" line-height="125%" y="807.18884" x="143.67186" font-family="Sans" fill="#000000"><tspan id="tspan4369-55-4" font-size="17.5px" y="807.18884" x="143.67186" font-family="&apos;Open Sans&apos;">Web Application</tspan></text>
   <text id="text4367-4-3-7" style="word-spacing:0px;letter-spacing:0px" xml:space="preserve" font-size="40px" line-height="125%" y="979.60266" x="439.99738" font-family="Sans" fill="#000000"><tspan id="tspan4389-9-6" font-size="17.5px" y="979.60266" x="439.99738" font-family="&apos;Open Sans&apos;">Data</tspan></text>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -200,8 +200,8 @@ section {
       }
       p {
         font-size: 0.8rem;
-        .developer { color: red; }
-        .user      { color: green; }
+        .developer { color: darken(#f5793a, 10%); }
+        .user      { color: darken(#85c0f9, 20%); }
       }
     }
   }


### PR DESCRIPTION
This blue and orange contrast should be viewable by the three most common types
of colorblindness. The text descriptions are darkened to read better. Really, I
made these colors up based on some articles I found about colorblind
accessiblity and what looks good, and I'm open to tweaking.

The weird white spot on the top of the cylinders was also removed.

Before: 
![image](https://user-images.githubusercontent.com/17414927/66216192-a505b200-e68a-11e9-8206-7c4160833fd0.png)

After: 
![image](https://user-images.githubusercontent.com/17414927/66216221-b2bb3780-e68a-11e9-8e9a-9d536704645a.png)

Note that the SVGs look like they were generated by some tool (because
of all the random-looking class and id names), but I just edited
manually. I don't know how these manual changes might interact with any
SVG editing tool.

One more note, I couldn't test this without #37 in my current environment.

Fixes #11