### PR TITLE
Add overhide.io RS hosted servers and the IAP onboarding application

### DIFF
--- a/apps.md
+++ b/apps.md
@@ -368,6 +368,16 @@ may be outdated.
 <li>Works well on mobile and desktop</li>
 </ul></td>
 </tr>
+<tr class="odd">
+<td><p><a href="https://overhide.github.io/armadietto/lucchetto/onboard.html#" target="_blank">Lucchetto Onboard</a></p></td>
+<td><p>Enables in-app purchase SKU onboarding for <a href="https://www.npmjs.com/package/lucchetto/v/latest" target="_blank">luchetto.js</a> extended RS apps</p></td>
+<td></td>
+<td><p><a href="https://github.com/overhide/armadietto/blob/master/lucchetto/onboard.html" target="_blank">GitHub</a></p></td>
+<td></td>
+<td><ul>
+<li>Featured in the <a href="https://github.com/overhide/remotestorage-tutorial" target="_blank">remote-storage tutorial</a></li>
+</ul></td>
+</tr>
 </tbody>
 </table>
 

--- a/servers.md
+++ b/servers.md
@@ -13,7 +13,7 @@ nav_order: 5
     remoteStorage on both shared and custom domains.
   - [overhide.io](https://overhide.io#baas) offers (paid) managed hosting
     and supports [lucchetto.js](https://www.npmjs.com/package/lucchetto/v/latest) 
-    RS apps with in-app purchases.
+    extended RS apps with in-app purchases.
 
 ## Host your own
 

--- a/servers.md
+++ b/servers.md
@@ -11,6 +11,9 @@ nav_order: 5
     remoteStorage provider that currently offers free storage accounts.
   - [IndieHosters](https://indie.host/) offers (paid) managed hosting of
     remoteStorage on both shared and custom domains.
+  - [overhide.io](https://overhide.io#baas) offers (paid) managed hosting
+    and supports [lucchetto.js](https://www.npmjs.com/package/lucchetto/v/latest) 
+    RS apps with in-app purchases.
 
 ## Host your own
 
@@ -22,6 +25,10 @@ nav_order: 5
     image](https://hub.docker.com/r/bnjbvr/mysteryshack-docker/))
   - [armadietto](https://github.com/remotestorage/armadietto/) is a
     remoteStorage server based on node.js
+  - [armadietto+lucchetto](https://github.com/overhide/armadietto/blob/master/lucchetto/README.md) 
+    is an [armadietto](https://github.com/remotestorage/armadietto/) fork
+    with middleware extensions including in-app purchase support ([Docker
+    image](https://hub.docker.com/repository/docker/overhide/armadietto))
 
 ## Integrate into existing systems
 


### PR DESCRIPTION
Add overhide.io servers to the list of RS hosted services.

Add the lucchetto in-app purchase SKU onboarding app to the list of apps.

Mentions the new [RS tutorial](https://github.com/overhide/remotestorage-tutorial).