### PR TITLE
Remove broken link

### DIFF
--- a/apps.md
+++ b/apps.md
@@ -95,7 +95,5 @@ may be outdated.
 
 ## Notes
 
-  - There's an old list in the modules repo:
-    <https://github.com/remotestorage/modules/blob/master/doc/apps.md>
   - Here's another list: <https://unhosted.org/apps/>
   - And another one (but not RS-only): <https://0data.app/>


### PR DESCRIPTION
Not sure if the place it should point to is worth sharing as there are no links https://github.com/remotestorage/modules/blob/72d7a0f4c1266c635bde1c90e1ffbebbe493c96a/doc/apps.md

and all working RS apps should be on our list by now anyway.