### PR TITLE
Redirect URLs with trailing slash

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -93,5 +93,19 @@ export default defineConfig({
       pageData.titleTemplate = 'remoteStorage.js'
     }
     return pageData;
+  },
+
+  async transformHtml(code, id, ctx) {
+    if (id.endsWith('404.html')) {
+      const redirectScript = `
+        <script>
+          if (window.location.pathname.endsWith('/') && window.location.pathname !== '/') {
+            window.location.replace(window.location.pathname.slice(0, -1));
+          }
+        </script>
+      `;
+      return code.replace('</head>', `${redirectScript}</head>`);
+    }
+    return code;
   }
 })


### PR DESCRIPTION
Strips the trailing slash and does a client-side redirect before the VitePress app can load.

refs #93